### PR TITLE
Update space for WolfDeFi 

### DIFF
--- a/spaces/wolfdefi/index.json
+++ b/spaces/wolfdefi/index.json
@@ -1,5 +1,5 @@
 {
-  "token": "0x4193f0e524B396E6291461c58948Ab48B2B8e52a",
+  "token": "0xB33FeD44291b302559869DEF4143C8B9D32024AF",
   "name": "WolfDeFi",
   "network": "4",
   "symbol": "WOLF",

--- a/spaces/wolfdefi/index.json
+++ b/spaces/wolfdefi/index.json
@@ -1,5 +1,5 @@
 {
-  "token": "0xB33FeD44291b302559869DEF4143C8B9D32024AF",
+  "token": "0x4193f0e524B396E6291461c58948Ab48B2B8e52a",
   "name": "WolfDeFi",
   "network": "4",
   "symbol": "WOLF",
@@ -8,7 +8,7 @@
     {
       "name": "erc20-balance-of",
       "params": {
-        "address": "0xB33FeD44291b302559869DEF4143C8B9D32024AF",
+        "address": "0x4193f0e524B396E6291461c58948Ab48B2B8e52a",
         "symbol": "WOLF",
         "decimals": 18
       }


### PR DESCRIPTION
Update space for WolfDeFi  - new token address 
  
Etherscan: https://rinkeby.etherscan.io/address/0x4193f0e524b396e6291461c58948ab48b2b8e52a  
Website: https://wolfdefi.com
Twitter: https://twitter.com/wolfdefi

