### PR TITLE
Update Alpha (BSC) token field

### DIFF
--- a/spaces/alpha-bsc/index.json
+++ b/spaces/alpha-bsc/index.json
@@ -1,5 +1,5 @@
 {
-  "token": "0xa1faa113cbE53436Df28FF0aEe54275c13B40975",
+  "token": "alpha-bsc",
   "name": "Alpha Finance (BSC)",
   "network": "56",
   "symbol": "ALPHA",


### PR DESCRIPTION
**Update Alpha (BSC) token field** 

Since we have discussed the issue on Discord

Now we try to add the proposal to Alpha (Ethereum) space and Alpha (BSC) but we have found an issue that:
```
1.) When we create the proposal for Alpha (BSC) then it's not shown on Alpha (BSC) space but it's shown on Alpha (Ethereum)
2.) When we click to the proposal that suppose to be BSC proposal on Alpha (Ethereum) space, the link will load but not show the proposal until we change the link to https://snapshot.page/#/alpha-bsc/proposal/QmUdikKXoZeAb82j81h2yPXPFPxXpUghHdXi3GuJHJZNPd
3. ) Note: Alpha (BSC) is always empty.
the proposal that suppose to be on Alpha(BSC) is QmUdikKXoZeAb82j81h2yPXPFPxXpUghHdXi3GuJHJZNPd
```
And Fabien recommended the solution:
```
The issue is that you use the same value "token" param on both spaces config. This field should be unique. You can change: 
token: "0xa1faa113cbE53436Df28FF0aEe54275c13B40975" 
to token: "alpha-bsc" on your BSC space to fix this issue, soon we will remove the field "token" and this wont be necessary.
```
  
Etherscan: https://etherscan.io/address/0xa1faa113cbE53436Df28FF0aEe54275c13B40975
CoinGecko: https://www.coingecko.com/en/coins/alpha-finance
Website: https://alphafinance.io/
Twitter: https://twitter.com/AlphaFinanceLab
