### PR TITLE
Set to only member proposals and hide invalid proposal on Alpha (Ethereum)

### DIFF
--- a/spaces/alpha-ethereum/index.json
+++ b/spaces/alpha-ethereum/index.json
@@ -19,9 +19,11 @@
   "filters": {
     "defaultTab": "all",
     "minScore": 0,
+    "onlyMembers": true,
     "invalids": [
       "QmPxoH2fDZSdWG241NbeQG6FcxnoQSnkxx3Z74Gj5815Wn",
-      "QmUdikKXoZeAb82j81h2yPXPFPxXpUghHdXi3GuJHJZNPd"
+      "QmUdikKXoZeAb82j81h2yPXPFPxXpUghHdXi3GuJHJZNPd",
+      "QmeZzF7eAfgz7to1mJmd8oCUF3xwWD5dT3b7z1W5eMeiZe"
     ]
   }
 }


### PR DESCRIPTION
**Set to only member proposals and hide invalid proposal on Alpha (Ethereum)**  
  
Etherscan: https://etherscan.io/address/0xa1faa113cbE53436Df28FF0aEe54275c13B40975
CoinGecko: https://www.coingecko.com/en/coins/alpha-finance
Website: https://alphafinance.io/
Twitter: https://twitter.com/AlphaFinanceLab
