### PR TITLE
Fix U+200d character in the Ethereum token address string

### DIFF
--- a/spaces/dawn/index.json
+++ b/spaces/dawn/index.json
@@ -8,7 +8,7 @@
     {
       "name": "erc20-balance-of",
       "params": {
-        "address": "‍0x580c8520dEDA0a441522AEAe0f9F7A5f29629aFa",
+        "address": "0x580c8520dEDA0a441522AEAe0f9F7A5f29629aFa",
         "symbol": "DAWN",
         "decimals": 18
       }


### PR DESCRIPTION
For some reason, the Dawn ERC-20 token address copy-pasted in the pull request to add Dawn governance had an invisible character embedded into it. Here is a fixed string, with the invisible Unicode character removed.

