### PR TITLE
Update strategy token address for Dracula Protocol to have a correct …

### DIFF
--- a/spaces/dracula/index.json
+++ b/spaces/dracula/index.json
@@ -7,7 +7,7 @@
     {
       "name": "erc20-balance-of",
       "params": {
-        "address": "0xc88a5d099f7daf8bb9511323502daddbda579d28",
+        "address": "0xc88a5D099F7DAF8bb9511323502dAddBda579D28",
         "symbol": "BLOOD",
         "decimals": 18
       }


### PR DESCRIPTION
Update strategy token address for Dracula Protocol to have a correct checksum.

We're having an issue with some proposals -- they don't display properly, e. g. https://snapshot.page/#/dracula/proposal/QmXfCrTY5zXFPG4xTMaSQB1iXB8TPTaHzuWkvpsGntCAQh

We think that the strategy token address having invalid checksum might be a reason.