### PR TITLE
Added 2 invalids to Digital Reserve Currency Space

### DIFF
--- a/spaces/digital-reserve-currency/index.json
+++ b/spaces/digital-reserve-currency/index.json
@@ -38,6 +38,10 @@
   ],
   "filters": {
     "defaultTab": "all",
-    "minScore": 1000
+    "minScore": 1000,
+    "invalids": [
+      "QmaawPXdWbdShDn6SmLiH7KMpbPHUj4MbWSRWuQEE8kbHE",
+      "QmRFqhYmNzCs4JigxYe3KwEwtkphaZKvv2GU3DpYZcWWq4"
+    ]
   }
 }


### PR DESCRIPTION
Included 2 invalids to previous proposals that are no longer accessible due to updating the Strategies for DRC