### PR TITLE
Add balance of yYFL strategy

### DIFF
--- a/spaces/yflink/index.json
+++ b/spaces/yflink/index.json
@@ -11,6 +11,14 @@
         "symbol": "YFL",
         "decimals": 18
       }
+    },
+    {
+      "name": "erc20-balance-of",
+      "params": {
+        "address": "0x75D1aA733920b14fC74c9F6e6faB7ac1EcE8482E",
+        "symbol": "yYFL",
+        "decimals": 18
+      }
     }
   ],
   "filters": {


### PR DESCRIPTION
Update our strategies to include the YFLink Staking Share (yYFL) token balances for off-chain voting.

**If you want to create a space follow this guide**

https://docs.snapshot.page/guides/create-a-space
