### PR TITLE
Update LEX space - make default tab `all` in index.json

### DIFF
--- a/spaces/lex/index.json
+++ b/spaces/lex/index.json
@@ -13,7 +13,7 @@
     }
   ],
   "filters": {
-    "defaultTab": "core",
+    "defaultTab": "all",
     "minScore": 1
   }
 }


### PR DESCRIPTION
make default tab for $LEX token holders `all`. This should improve visibility of background proposals.
