### PR TITLE
Add metafactory.eth to aliases

### DIFF
--- a/spaces/aliases.json
+++ b/spaces/aliases.json
@@ -4,5 +4,6 @@
   "yam": "yam.eth",
   "velotoken": "velotoken.eth",
   "cream": "cream-finance.eth",
-  "bzx": "bzx.eth"
+  "bzx": "bzx.eth",
+  "metafactory": "metafactory.eth"
 }


### PR DESCRIPTION
@gokaiorg I followed the instructions to migrate but none of the previous proposals show up (https://snapshot.page/#/metafactory.eth/)

Once this is merged, will the old proposals visible on https://snapshot.page/#/metafactory be visible?