### PR TITLE
Causing Error while installing in snapshot

### DIFF
--- a/spaces/domains.json
+++ b/spaces/domains.json
@@ -143,5 +143,5 @@
   "voting.itam.games": "itam.eth",
   "snapshot.valuedefi.io": "gvvalue.eth",
   "vote.bingocash.fi": "bingocash.eth",
-  "gov.apoyield.com": "apoyield.eth",
+  "gov.apoyield.com": "apoyield.eth"
 }


### PR DESCRIPTION
```
 ERROR  Failed to compile with 1 error                                                                                                
 error  in ./node_modules/@snapshot-labs/snapshot-spaces/spaces/domains.json
 Module parse failed: Unexpected token } in JSON at position 5736 while parsing near '...m": "apoyield.eth",
```