### PR TITLE
(Windows) index.json path is not removed in space id

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -17,7 +17,7 @@ export default Object.fromEntries(
     )
     .map(file => {
       const space = requireSpace(file);
-      const key = file.replace('./', '').replace('/index.json', '');
+      const key = file.replace('./', '').replace('/index.json', '').replace('\\index.json', '');
       return [key, space];
     })
 );


### PR DESCRIPTION
####

In windows, index.json is not being removed in space Ids

for example:
![image](https://user-images.githubusercontent.com/15967809/115991267-55c50080-a5e5-11eb-95fd-0a8d842c08c9.png)
