### PR TITLE
streamr -> streamr.eth in domains.json

### DIFF
--- a/spaces/domains.json
+++ b/spaces/domains.json
@@ -65,7 +65,7 @@
   "vote.pancakebunny.finance": "pancakebunny.eth",
   "vote.taconomics.io": "taco",
   "gov.narwhalswap.org": "narwhal",
-  "vote.streamr.network": "streamr",
+  "vote.streamr.network": "streamr.eth",
   "governance.etgproject.org": "etgfinance",
   "gov.pokt.network": "pokt-network",
   "vote.niceee.org": "nice",


### PR DESCRIPTION
The custom url `https://vote.streamr.network/` broke when migrating the space from legacy to ENS based. Hoping this will fix it!