### PR TITLE
Correct ENS domain for cronosfrens

### DIFF
--- a/spaces/domains.json
+++ b/spaces/domains.json
@@ -532,7 +532,7 @@
   "vote.alphadao.money": "alphagov.eth",
   "vote.jfscaramazza.com": "jfscaramazza.eth",
   "signal.paladin.vote": "palvote.eth",
-  "dao.cronosfrens.io": "cronosfrens.io",
+  "dao.cronosfrens.io": "cronosfrens.eth",
   "vote.tresleches.finance": "3Leches.eth",
   "gov.wagumi.xyz": "wagumi.eth",
   "vote.huckleberry.finance": "huckleberrydex.eth",


### PR DESCRIPTION
Changed cronosfrens.io to cronosfrens.eth

#### Hi! What is your PR about?

- [ ] Add or edit a skin
- [X] Add a custom domain for your space
- [ ] Add an alias to migrate your space
