### PR TITLE
removed duplicate domain

### DIFF
--- a/spaces/domains.json
+++ b/spaces/domains.json
@@ -642,7 +642,6 @@
   "dao.astraguild.io": "astraguildventures.eth",
   "vote.cyberfrogz.io": "cyberz.eth",
   "governance.domani.finance": "dextfprotocol.eth",
-  "governance.dao.domani.finance": "domaniprotocol.eth",
   "vote.forwardprotocol.io": "forwardprotocol.eth",
   "gov.hpb.io": "xinlian.eth",
   "vote.fantomstarter.io": "fantomstarter.eth",


### PR DESCRIPTION
The domain `governance.dao.domani.finance` was listed twice, causing the space not to load because the second entry's ENS domain doesn't exist as a space.
