### PR TITLE
Updating Altrucoin.io to .com

### DIFF
--- a/spaces/domains.json
+++ b/spaces/domains.json
@@ -492,7 +492,7 @@
   "vote.spooky.fi": "spookyswap.eth",
   "vote.glidefinance.io": "glidefinance.eth",
   "signal.ampleforth.org": "ampleforthorg.eth",
-  "vote.altrucoin.io": "altrucoin.eth",
+  "vote.altrucoin.com": "altrucoin.eth",
   "voting.font.community": "fontcommunity.eth",
   "snapshot.vswap.fi": "vbswap.eth",
   "vote.munchproject.io": "munchproject.eth",


### PR DESCRIPTION
The official website has moved to .com (.io redirects there) so we are moving the voting app there too. Thank you

#### Hi! What is your PR about?

- [ ] Add or edit a skin
- [X] Add a custom domain for your space
- [ ] Add an alias to migrate your space
