### PR TITLE
Revert "Verify solidefied.eth"

### DIFF
--- a/spaces/domains.json
+++ b/spaces/domains.json
@@ -704,7 +704,6 @@
   "vote.cyberfrogz.io": "cyberz.eth",
   "governance.domani.finance": "dextfprotocol.eth",
   "vote.forwardprotocol.io": "forwardprotocol.eth",
-  "dao.solidefied.io": "solidefied.eth",
   "gov.hpb.io": "xinlian.eth",
   "vote.fantomstarter.io": "fantomstarter.eth",
   "vote.netswap.io": "venett.eth",


### PR DESCRIPTION
Reverts snapshot-labs/snapshot-spaces#2193
Reason: Typo error in data provided for subdomain.