### PR TITLE
Tweak border color for primary button on moonwell.scss

### DIFF
--- a/skins/moonwell.scss
+++ b/skins/moonwell.scss
@@ -20,7 +20,7 @@
   }
 
   .button--primary{
-    border-color: #efc705 !important;
+    border-color: transparent !important;
     background: transparent;
     transition: background 0.5s;
   }


### PR DESCRIPTION
#### Hi! What is your PR about?

Small edit for the skin, right now primary buttons have a yellow outline. 

<img width="206" alt="image" src="https://user-images.githubusercontent.com/97316189/186473939-71c7a06e-a83e-4760-b2ef-f8b0cd96e939.png">

Forcing transparent boarder seems to solve it

<img width="207" alt="image" src="https://user-images.githubusercontent.com/97316189/186474046-0a3b85f2-aae9-4b86-9303-ff3080b33ebb.png">

- [X] Add or edit a skin
- [ ] Add a custom domain for your space
- [ ] Add an alias to migrate your space
