### PR TITLE
Fix styling for Navbar on all themes

### DIFF
--- a/skins/aave.scss
+++ b/skins/aave.scss
@@ -8,7 +8,7 @@
   --header-bg: #f7f7f7;
   --block-bg: white;
 
-  #topnav {
+  #navbar {
     border-bottom: 4px solid black !important;
     border-image-slice: 1;
     border-image-source: linear-gradient(to left, #b6509e, #2ebac6);

--- a/skins/aavegotchi.scss
+++ b/skins/aavegotchi.scss
@@ -8,7 +8,7 @@
   --header-bg: #f741f0;
   --block-bg: transparent;
 
-  #topnav {
+  #navbar {
     border-bottom: 4px solid black !important;
     border-image-slice: 1;
     border-image-source: linear-gradient(to left, #f741f0, #04b7bc);

--- a/skins/adex.scss
+++ b/skins/adex.scss
@@ -1,16 +1,20 @@
 .adex {
-    --primary-color: #ff4269;
-    --bg-color: #1A1825;
-    --text-color: #a6a6a6;
-    --link-color: #fafafa;
-    --heading-color: #fafafa;
-    --border-color: #a6a6a6;
-    --header-bg: #29253b;
-    --block-bg: #29253b;
+  --primary-color: #ff4269;
+  --bg-color: #1a1825;
+  --text-color: #a6a6a6;
+  --link-color: #fafafa;
+  --heading-color: #fafafa;
+  --border-color: #a6a6a6;
+  --header-bg: #29253b;
+  --block-bg: #29253b;
 
-    #topnav {
-      border-bottom: 4px solid black !important;
-      border-image-slice: 1;
-      border-image-source:  linear-gradient(90deg, rgba(73,69,96,1) 0%, rgba(255,66,105,1) 100%);
-    }
+  #navbar {
+    border-bottom: 4px solid black !important;
+    border-image-slice: 1;
+    border-image-source: linear-gradient(
+      90deg,
+      rgba(73, 69, 96, 1) 0%,
+      rgba(255, 66, 105, 1) 100%
+    );
+  }
 }

--- a/skins/amp.scss
+++ b/skins/amp.scss
@@ -8,7 +8,7 @@
   --header-bg: #ffffff;
   --block-bg: white;
 
-  #topnav {
+  #navbar {
     border-bottom: 4px solid black !important;
     border-image-slice: 1;
     border-image-source: linear-gradient(to left, #c9328f, #9b30c5);

--- a/skins/apy.scss
+++ b/skins/apy.scss
@@ -8,7 +8,7 @@
   --header-bg: #202020;
   --block-bg: #1a1a1a;
 
-  #topnav {
+  #navbar {
     border-bottom: 2px solid black !important;
     border-image-slice: 1;
     border-image-source: linear-gradient(to left, #483dc2, #d556f5);

--- a/skins/ballena.scss
+++ b/skins/ballena.scss
@@ -8,7 +8,7 @@
   --header-bg: #1d3149;
   --block-bg: #121e2c;
 
-  #topnav {
+  #navbar {
     border-bottom: 1px solid #d8f2fe !important;
   }
 }

--- a/skins/bancor.scss
+++ b/skins/bancor.scss
@@ -8,16 +8,17 @@
   --header-bg: #18181a;
   --block-bg: transparent;
 
-  #topnav {
-    background-color:#18181a;
-    border-bottom: 1px solid #ffffff!important;
+  #navbar {
+    background-color: #18181a;
+    border-bottom: 1px solid #ffffff !important;
   }
 
-  #topnav a, #topnav .text-gray {
+  #navbar a,
+  #navbar .text-gray {
     color: #ffffff !important;
   }
 
-  #topnav button {
+  #navbar button {
     border-color: #ffffff;
     color: #ffffff;
   }

--- a/skins/benchmark.scss
+++ b/skins/benchmark.scss
@@ -8,7 +8,7 @@
   --header-bg: #2a2e35;
   --block-bg: transparent;
 
-  #topnav {
+  #navbar {
     border-bottom: 4px solid #2cf48b !important;
   }
 }

--- a/skins/betswirl.scss
+++ b/skins/betswirl.scss
@@ -1,17 +1,15 @@
 .betswirl {
-  --primary-color: #5965F1;
+  --primary-color: #5965f1;
   --bg-color: #101420;
   --text-color: #ffffff;
   --link-color: white;
   --heading-color: #fff;
-  --border-color: #818CF6;
-  --header-bg: #151B2B;
-  --block-bg: #151B2B;
-  
-  
-  #topnav {
-      background-color: #151B2B;
-      border: none !important;
-  }
+  --border-color: #818cf6;
+  --header-bg: #151b2b;
+  --block-bg: #151b2b;
 
+  #navbar {
+    background-color: #151b2b;
+    border: none !important;
+  }
 }

--- a/skins/clucoin.scss
+++ b/skins/clucoin.scss
@@ -7,11 +7,10 @@
   --border-color: #424242;
   --header-bg: 0a0909;
   --block-bg: #0a0909;
-    
-  #topnav {
+
+  #navbar {
     border-bottom: 4px solid #ec008c !important;
     border-image-slice: 1;
-    border-image-source: linear-gradient(270deg,#ff008c,#bd0084);
+    border-image-source: linear-gradient(270deg, #ff008c, #bd0084);
   }
-  
 }

--- a/skins/elementfinance.scss
+++ b/skins/elementfinance.scss
@@ -1,16 +1,16 @@
 .elementfinance {
-  --primary-color: #005EBE;
-  --bg-color: #F1F5FE;
+  --primary-color: #005ebe;
+  --bg-color: #f1f5fe;
   --text-color: #979797;
-  --link-color: #75C7EE;
-  --heading-color: #75C7EE;
+  --link-color: #75c7ee;
+  --heading-color: #75c7ee;
   --border-color: #d1d5da;
   --header-bg: #f7f7f7;
   --block-bg: white;
 
-  #topnav {
+  #navbar {
     border-bottom: 4px solid black !important;
     border-image-slice: 1;
-    border-image-source: linear-gradient(to left, #78D3E2, #005EBE);
+    border-image-source: linear-gradient(to left, #78d3e2, #005ebe);
   }
 }

--- a/skins/halodao.scss
+++ b/skins/halodao.scss
@@ -1,14 +1,14 @@
 .halodao {
-  --bg-color: #FBFAFF;
-  --text-color: #4F4F4F; 
-  --link-color: #471BB2;
+  --bg-color: #fbfaff;
+  --text-color: #4f4f4f;
+  --link-color: #471bb2;
   --heading-color: #111111;
   --border-color: #471bb2;
   --header-bg: #ffffff;
   --block-bg: #ffffff;
 
-  #topnav {
+  #navbar {
     background-color: #ffffff;
-    border-bottom: 1px solid #15006D !important;
+    border-bottom: 1px solid #15006d !important;
   }
 }

--- a/skins/keyfi.scss
+++ b/skins/keyfi.scss
@@ -1,16 +1,16 @@
 .keyfi {
-    --primary-color: #00CAED;
-    --bg-color: #F8F9FC;
-    --text-color: #555C68;
-    --link-color: #111111;
-    --heading-color: #111111;
-    --border-color: #D3DEEE;
-    --header-bg: #E6ECF5;
-    --block-bg: white;
+  --primary-color: #00caed;
+  --bg-color: #f8f9fc;
+  --text-color: #555c68;
+  --link-color: #111111;
+  --heading-color: #111111;
+  --border-color: #d3deee;
+  --header-bg: #e6ecf5;
+  --block-bg: white;
 
-    #topnav {
-        border-bottom: 4px solid black !important;
-        border-image-slice: 1;
-        border-image-source: linear-gradient(to left, #40D6F5, #1EACE7);
-    }
+  #navbar {
+    border-bottom: 4px solid black !important;
+    border-image-slice: 1;
+    border-image-source: linear-gradient(to left, #40d6f5, #1eace7);
+  }
 }

--- a/skins/lido.scss
+++ b/skins/lido.scss
@@ -1,15 +1,15 @@
 .lido {
-  --primary-color: #00A3FF;
-  --bg-color: #F4F6F8;
-  --text-color: #505A7A;
-  --link-color: #080E14;
-  --heading-color: #080E14;
-  --border-color: #C8D0D8;
+  --primary-color: #00a3ff;
+  --bg-color: #f4f6f8;
+  --text-color: #505a7a;
+  --link-color: #080e14;
+  --heading-color: #080e14;
+  --border-color: #c8d0d8;
   --header-bg: #ffffff;
   --block-bg: #ffffff;
-  #topnav {
-    border-bottom: 4px solid #F69988 !important;
+  #navbar {
+    border-bottom: 4px solid #f69988 !important;
     border-image-slice: 1;
-    border-image-source: linear-gradient(90deg, #F69988 0%, #00A3FF 100%);
+    border-image-source: linear-gradient(90deg, #f69988 0%, #00a3ff 100%);
   }
-  }
+}

--- a/skins/masknetwork.scss
+++ b/skins/masknetwork.scss
@@ -1,6 +1,6 @@
 .masknetwork {
-  --primary-color: #1C68F3;
-  --bg-color: #F7f8f9;
+  --primary-color: #1c68f3;
+  --bg-color: #f7f8f9;
   --text-color: #382626;
   --link-color: #111111;
   --heading-color: #111111;
@@ -8,18 +8,18 @@
   --header-bg: white;
   --block-bg: white;
 
-  #topnav {
-    background-color: #1C68F3;
-    border-bottom: 3px solid #0657F9 !important;
+  #navbar {
+    background-color: #1c68f3;
+    border-bottom: 3px solid #0657f9 !important;
     border-image-slice: 1;
-    border-image-source: linear-gradient(to left, #095EB5, #0077FC);
+    border-image-source: linear-gradient(to left, #095eb5, #0077fc);
   }
 
-  #topnav a {
+  #navbar a {
     color: white !important;
   }
 
-  #topnav button {
+  #navbar button {
     border-color: white;
     color: white;
   }

--- a/skins/mero.scss
+++ b/skins/mero.scss
@@ -1,44 +1,49 @@
 .mero {
-  --primary-color: #C532F9;
+  --primary-color: #c532f9;
   --bg-color: #0a0622;
   --text-color: #9d9ca6;
   --link-color: white;
   --heading-color: white;
   --border-color: transparent;
-  --header-bg: #1C0B38;
-  --block-bg: #0F0830;
+  --header-bg: #1c0b38;
+  --block-bg: #0f0830;
 
-  #topnav {
+  #navbar {
     border-bottom: 4px solid black !important;
     border-image-slice: 1;
-    border-image-source: linear-gradient(to right, #C532F9, #32B2E5);
+    border-image-source: linear-gradient(to right, #c532f9, #32b2e5);
   }
-  
+
   .bg-skin-header-bg {
     position: relative !important;
   }
-  
+
   .bg-skin-header-bg:after {
     content: "";
     width: 100%;
     height: 3px;
-    background: linear-gradient(to right, #C532F9, #32B2E5);
+    background: linear-gradient(to right, #c532f9, #32b2e5);
     bottom: -3px;
     left: 0;
     position: absolute;
     opacity: 0.2;
   }
-  
+
   .button--primary {
     transition: background-position 0.5s !important;
     background-size: 200% auto !important;
     border: none !important;
     background-origin: border-box !important;
     background-clip: padding-box, border-box !important;
-    background-image: linear-gradient(to right, #C532F9 0%, #32B2E5 50%, #C532F9 100%) !important;
+    background-image: linear-gradient(
+      to right,
+      #c532f9 0%,
+      #32b2e5 50%,
+      #c532f9 100%
+    ) !important;
     filter: brightness(1) !important;
   }
-  
+
   .button--primary:hover {
     background-position: right center !important;
   }

--- a/skins/moonbeans.scss
+++ b/skins/moonbeans.scss
@@ -1,16 +1,16 @@
 .moonbeans {
-    --primary-color: #40e5e1;
-    --bg-color: #121212;
-    --text-color: #e8e8e8;
-    --link-color: #e8e8e8;
-    --heading-color: #FF2B97;
-    --border-color: #424242;
-    --header-bg: #121212;
-    --block-bg: transparent;
+  --primary-color: #40e5e1;
+  --bg-color: #121212;
+  --text-color: #e8e8e8;
+  --link-color: #e8e8e8;
+  --heading-color: #ff2b97;
+  --border-color: #424242;
+  --header-bg: #121212;
+  --block-bg: transparent;
 
-    #topnav {
-        border-bottom: 4px solid black !important;
-        border-image-slice: 1;
-        border-image-source: linear-gradient(to left, #40e5e1, #FF2B97);
-      }
+  #navbar {
+    border-bottom: 4px solid black !important;
+    border-image-slice: 1;
+    border-image-source: linear-gradient(to left, #40e5e1, #ff2b97);
   }
+}

--- a/skins/moontools.scss
+++ b/skins/moontools.scss
@@ -1,14 +1,14 @@
 .moontools {
-  --primary-color: #84FFFF;
+  --primary-color: #84ffff;
   --bg-color: #000000;
   --text-color: white;
-  --link-color: #84FFFF;
+  --link-color: #84ffff;
   --heading-color: white;
   --border-color: rgba(255, 255, 255, 0.2);
   --header-bg: #000000;
   --block-bg: transparent;
 
-  #topnav {
+  #navbar {
     border-bottom: 2px solid white !important;
   }
 }

--- a/skins/nation3.scss
+++ b/skins/nation3.scss
@@ -8,7 +8,7 @@
   --header-bg: white;
   --block-bg: white;
 
-  #topnav {
+  #navbar {
     border-bottom: 4px solid black !important;
     border-image-slice: 1;
     border-image-source: linear-gradient(to right, #69c9ff, #88f1bb);

--- a/skins/poh.scss
+++ b/skins/poh.scss
@@ -1,6 +1,6 @@
 .poh {
-  --primary-color: #FFC700;
-  --bg-color: #FFFDF6;
+  --primary-color: #ffc700;
+  --bg-color: #fffdf6;
   --text-color: #8c8c8c;
   --link-color: #111111;
   --heading-color: #111111;
@@ -8,9 +8,9 @@
   --header-bg: white;
   --block-bg: white;
 
-  #topnav {
+  #navbar {
     border-bottom: 3px solid black !important;
     border-image-slice: 1;
-    border-image-source: linear-gradient(to left, #FDC9D3, #FF9900);
+    border-image-source: linear-gradient(to left, #fdc9d3, #ff9900);
   }
 }

--- a/skins/pokt-network.scss
+++ b/skins/pokt-network.scss
@@ -2,13 +2,13 @@
   --primary-color: #a400a6;
   --bg-color: #182129;
   --text-color: #969696;
-  --link-color: #1D8AED;
+  --link-color: #1d8aed;
   --heading-color: #fafafa;
   --border-color: transparent;
   --header-bg: #182129;
-  --block-bg: #111B23;
-  
-  #topnav {
+  --block-bg: #111b23;
+
+  #navbar {
     border-bottom: 4px solid transparent;
     border-image-slice: 1;
     border-image-source: linear-gradient(to left, #b9f000, #182129);

--- a/skins/prepo.scss
+++ b/skins/prepo.scss
@@ -8,16 +8,17 @@
   --header-bg: white;
   --block-bg: white;
 
-  #topnav {
+  #navbar {
     background-color: #454699;
     border-bottom: 1px solid #454699 !important;
   }
 
-  #topnav a, #topnav .text-gray {
+  #navbar a,
+  #navbar .text-gray {
     color: white !important;
   }
 
-  #topnav button {
+  #navbar button {
     border-color: white;
     color: white;
   }

--- a/skins/rhino.scss
+++ b/skins/rhino.scss
@@ -1,16 +1,16 @@
 .rhino {
-  --primary-color: #6BCACE;
+  --primary-color: #6bcace;
   --bg-color: #f1f1f3;
   --text-color: #707070;
   --link-color: #111111;
-  --heading-color: #6BCACE;
+  --heading-color: #6bcace;
   --border-color: #d1d5da;
   --header-bg: #f7f7f7;
   --block-bg: white;
 
-  #topnav {
+  #navbar {
     border-bottom: 5px solid !important;
     border-image-slice: 1;
-    border-image-source: linear-gradient(to right, #fde699, #F05558, #6BCACE);
+    border-image-source: linear-gradient(to right, #fde699, #f05558, #6bcace);
   }
 }

--- a/skins/shabushabu.scss
+++ b/skins/shabushabu.scss
@@ -8,7 +8,7 @@
   --header-bg: #ffffff;
   --block-bg: white;
 
-  #topnav {
+  #navbar {
     border-bottom: 4px solid black !important;
     border-image-slice: 1;
     border-image-source: linear-gradient(to left, #c9328f, #9b30c5);

--- a/skins/six.scss
+++ b/skins/six.scss
@@ -1,18 +1,18 @@
 .six {
-    --primary-color: #1f1f1f;
-    --bg-color: #131313;
-    --text-color: white;
-    --link-color: white;
-    --heading-color: white;
-    --border-color: #373737;
-    --header-bg: #131313;
+  --primary-color: #1f1f1f;
+  --bg-color: #131313;
+  --text-color: white;
+  --link-color: white;
+  --heading-color: white;
+  --border-color: #373737;
+  --header-bg: #131313;
 
-    #topnav .router-link-exact-active,
-    #topnav .router-link-active {
-        font-size: 0 !important;
-        line-height: 0;
-        width: 0;
-        height: 0;
-        display: none;
-    }
+  #navbar .router-link-exact-active,
+  #navbar .router-link-active {
+    font-size: 0 !important;
+    line-height: 0;
+    width: 0;
+    height: 0;
+    display: none;
+  }
 }

--- a/skins/stakewise.scss
+++ b/skins/stakewise.scss
@@ -8,17 +8,17 @@
   --header-bg: #27293d;
   --block-bg: #27293d;
 
-  #topnav {
+  #navbar {
     background-color: #1d8cf8;
     border-image-slice: 1;
     border-image-source: linear-gradient(to left, #1d8cf8, #3358f4);
   }
 
-  #topnav a {
+  #navbar a {
     color: white !important;
   }
 
-  #topnav button {
+  #navbar button {
     border-color: white;
     color: white;
   }

--- a/skins/xpunks.scss
+++ b/skins/xpunks.scss
@@ -2,15 +2,15 @@
   --primary-color: #ffbf00;
   --bg-color: white;
   --text-color: #2d3748;
-  --link-color: #6B2D5C;
+  --link-color: #6b2d5c;
   --heading-color: #111111;
-  --border-color: #6B2D5C;
+  --border-color: #6b2d5c;
   --header-bg: white;
   --block-bg: transparent;
 
-  #topnav {
+  #navbar {
     border-bottom: 4px solid transparent;
     border-image-slice: 1;
-    border-image-source: linear-gradient(to left, #ffbf00, #6B2D5C);
+    border-image-source: linear-gradient(to left, #ffbf00, #6b2d5c);
   }
 }

--- a/skins/yaxis.scss
+++ b/skins/yaxis.scss
@@ -8,7 +8,7 @@
   --header-bg: white;
   --block-bg: white;
 
-  #topnav {
+  #navbar {
     background: linear-gradient(180deg, #016eac 20.17%, #52b2dc 100%);
   }
 }

--- a/skins/yearn.scss
+++ b/skins/yearn.scss
@@ -1,5 +1,5 @@
 .yearn {
-  --primary-color: #0657F9;
+  --primary-color: #0657f9;
   --bg-color: white;
   --text-color: #586069;
   --link-color: #111111;
@@ -8,16 +8,17 @@
   --header-bg: white;
   --block-bg: white;
 
-  #topnav {
-    background-color: #0657F9;
-    border-bottom: 1px solid #0657F9 !important;
+  #navbar {
+    background-color: #0657f9;
+    border-bottom: 1px solid #0657f9 !important;
   }
 
-  #topnav a, #topnav .text-gray {
+  #navbar a,
+  #navbar .text-gray {
     color: white !important;
   }
 
-  #topnav button {
+  #navbar button {
     border-color: white;
     color: white;
   }

--- a/skins/yup.scss
+++ b/skins/yup.scss
@@ -8,9 +8,16 @@
   --header-bg: #f7f7f7;
   --block-bg: white;
 
-  #topnav {
+  #navbar {
     border-bottom: 4px solid black !important;
     border-image-slice: 1;
-    border-image-source: linear-gradient(to left, #be1e2d, #f08c28, #f0c800, #7fba1b, #00eab7);
+    border-image-source: linear-gradient(
+      to left,
+      #be1e2d,
+      #f08c28,
+      #f0c800,
+      #7fba1b,
+      #00eab7
+    );
   }
 }


### PR DESCRIPTION
On the snapshot site, the navbar used to have the id `topnav`.  
A lot of themes would use the id selector of `#topnav` to adjust the styling of this navbar.  
However, recently the snapshot website updated and renamed this id to `navbar` which broke the styling for all these themes.  
This PR updates all css selectors from `#topnav` to `#navbar` to fix this issue.