### PR TITLE
Modify vote.zechub.xyz to vote.zechub.org

### DIFF
--- a/spaces/domains.json
+++ b/spaces/domains.json
@@ -1,7 +1,7 @@
 {
   "vote.moondao.com": "tomoondao.eth",
   "crypto-legal-action.mycryptolawyer.xyz": "mycryptolawyer.eth",
-  "vote.zechub.xyz": "zechubdao.eth",
+  "vote.zechub.org": "zechubdao.eth",
   "tvote.cascadia.foundation": "testcascadia.eth",
   "dao.dicesia.com": "dicesia.eth",
   "vote.hash2o.com": "hash2o.eth",


### PR DESCRIPTION
ZecHub DAO recently acquired zechub.org domain and we decide to move our snapshot page to this new domain.

Looks like the new line at the end of the file was auto-modified by GitHub web editor. I didn't touch that part of the file.

#### Hi! What is your PR about?

- [ ] Add or edit a skin
- [x] Add a custom domain for your space
- [ ] Add an alias to migrate your space
