### PR TITLE
Create submodule-update.yml

### DIFF
--- a/.github/workflows/submodule-update.yml
+++ b/.github/workflows/submodule-update.yml
@@ -1,0 +1,44 @@
+---
+name: Submodule Updates
+
+#############################
+# Start the job on all push #
+#############################
+on:
+  push:
+    branches-ignore: master
+  pull_request:
+    branches: master
+
+###############
+# Set the Job #
+###############
+jobs:
+  build:
+    name: Submodule update
+    runs-on: ubuntu-latest
+    env:
+      PARENT_REPOSITORY: 'snapshot-labs/snapshot'
+      CHECKOUT_BRANCH: 'master'
+      PR_AGAINST_BRANCH: 'master'
+      OWNER: 'snapshot-labs'
+
+    steps:
+      ##########################
+      # Checkout the code base #
+      ##########################
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      ####################################
+      # Run the action against code base #
+      ####################################
+      - name: run action
+        id: run_action
+        uses: releasehub-com/github-action-create-pr-parent-submodule@v1
+        with:
+          github_token: ${{ secrets.RELEASE_HUB_SECRET }}
+          parent_repository: ${{ env.PARENT_REPOSITORY }}
+          checkout_branch: ${{ env.CHECKOUT_BRANCH}}
+          pr_against_branch: ${{ env.PR_AGAINST_BRANCH }}
+          owner: ${{ env.OWNER }}

--- a/.github/workflows/submodule-update.yml
+++ b/.github/workflows/submodule-update.yml
@@ -6,9 +6,8 @@ name: Submodule Updates
 #############################
 on:
   push:
-    branches-ignore: master
-  pull_request:
-    branches: master
+    branches:
+      - master
 
 ###############
 # Set the Job #

--- a/.github/workflows/submodule-update.yml
+++ b/.github/workflows/submodule-update.yml
@@ -36,7 +36,7 @@ jobs:
         id: run_action
         uses: releasehub-com/github-action-create-pr-parent-submodule@v1
         with:
-          github_token: ${{ secrets.RELEASE_HUB_SECRET }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           parent_repository: ${{ env.PARENT_REPOSITORY }}
           checkout_branch: ${{ env.CHECKOUT_BRANCH}}
           pr_against_branch: ${{ env.PR_AGAINST_BRANCH }}


### PR DESCRIPTION
Adding a new GitHub Actions workflow, submodule-update.yml. This workflow kicks in every time there's a push to `master`, and it will create a new PR with the updates on `snapshot` the parent repository. 

### Why do we need this?
Keeping submodules up-to-date in the parent repository manually is a chore.