### PR TITLE
Add Streamr to "protocol" category

### DIFF
--- a/spaces/categories.json
+++ b/spaces/categories.json
@@ -170,7 +170,9 @@
     "protocol"
   ],
   "tokenlon.eth": [],
-  "streamr.eth": [],
+  "streamr.eth": [
+    "protocol"
+  ],
   "unlock-protocol.eth": [
     "protocol"
   ],


### PR DESCRIPTION
#### Hi! What is your PR about?

- [ ] Add or edit a skin
- [ ] Add a custom domain for your space
- [ ] Add an alias to migrate your space

I noticed the projects are categorized in categories.json. Snapshot is used for the governance of the Streamr Network protocol: tweaking parameters, adjusting rules. Maybe it would fit in the "protocol" category?